### PR TITLE
Add a batch warn page

### DIFF
--- a/src/components/BaseStatus.svelte
+++ b/src/components/BaseStatus.svelte
@@ -1,0 +1,71 @@
+<script lang="ts" context="module">
+  export const STATUS = {
+    IDLE: Symbol('idle'),
+    WORKING: Symbol('working'),
+    SUCCESS: Symbol('success'),
+    NOT_FOUND: Symbol('error-404'),
+    ERROR_INVALID: Symbol('error-invalid'),
+    ERROR_UNAUTHORIZED: Symbol('error-unauthorized'),
+    DUPLICATE: Symbol('duplicate'),
+    ERROR_OTHER: Symbol('error-other'),
+    PRIVATEUUID_MISSING: Symbol('private-uuid-missing'),
+  };
+</script>
+
+<script lang="ts">
+  export let status;
+</script>
+
+{#if status == STATUS.IDLE}Ready!{/if}
+{#if status == STATUS.WORKING}
+  <div class="lds-dual-ring" />
+  Sending request...
+{/if}
+{#if status == STATUS.SUCCESS}Done. Success!{/if}
+{#if status == STATUS.ERROR_INVALID}
+  <span class="error">Bad Request (Your inputs are wrong/impossible)</span>
+{/if}
+{#if status == STATUS.ERROR_UNAUTHORIZED}
+  <span class="error">Error. You are not allowed to do that!</span>
+{/if}
+{#if status == STATUS.DUPLICATE}
+  <span class="error">Error: Duplicate</span>
+{/if}
+{#if status == STATUS.ERROR_OTHER}
+  <span class="error">Error</span>
+{/if}
+{#if status == STATUS.NOT_FOUND}
+  <span class="error">Error: Not found!</span>
+{/if}
+{#if status == STATUS.PRIVATEUUID_MISSING}(Private UUID required){/if}
+
+<style>
+  .error {
+    color: red;
+  }
+  .lds-dual-ring {
+    display: inline-block;
+    vertical-align: middle;
+    width: 1em;
+    height: 1em;
+  }
+  .lds-dual-ring:after {
+    content: ' ';
+    display: block;
+    width: 0.8em;
+    height: 0.8em;
+    margin: 0.1em;
+    border-radius: 50%;
+    border: 0.075em solid #fff;
+    border-color: #fff transparent #fff transparent;
+    animation: lds-dual-ring 1.2s linear infinite;
+  }
+  @keyframes lds-dual-ring {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/src/components/MultiStatus.svelte
+++ b/src/components/MultiStatus.svelte
@@ -1,0 +1,28 @@
+<script lang="ts" context="module">
+  export {STATUS} from "./BaseStatus.svelte";
+</script>
+
+<script lang="ts">
+  import BaseStatus, {STATUS} from "./BaseStatus.svelte";
+  export let status: [string, symbol][] = [];
+  
+</script>
+
+<div class="status">
+  Status: 
+  {#if Object.values(status).length == 0}
+    <BaseStatus status={STATUS.IDLE} />
+  {:else}
+    <ul>
+      {#each status as [name, substatus] }
+        <li>{name}: <BaseStatus status={substatus} /></li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  ul {
+    margin: 0;
+  }
+</style>

--- a/src/components/Status.svelte
+++ b/src/components/Status.svelte
@@ -1,69 +1,12 @@
 <script lang="ts" context="module">
-  export const STATUS = {
-    IDLE: Symbol('idle'),
-    WORKING: Symbol('working'),
-    SUCCESS: Symbol('success'),
-    NOT_FOUND: Symbol('error-404'),
-    ERROR_INVALID: Symbol('error-invalid'),
-    ERROR_UNAUTHORIZED: Symbol('error-unauthorized'),
-    DUPLICATE: Symbol('duplicate'),
-    PRIVATEUUID_MISSING: Symbol('private-uuid-missing'),
-  };
+  export {STATUS} from "./BaseStatus.svelte";
 </script>
 
 <script lang="ts">
+  import BaseStatus from "./BaseStatus.svelte";
   export let status;
 </script>
 
 <div class="status">
-  Status: {#if status == STATUS.IDLE}Ready!{/if}
-  {#if status == STATUS.WORKING}
-    <div class="lds-dual-ring" />
-    Sending request...
-  {/if}
-  {#if status == STATUS.SUCCESS}Done. Success!{/if}
-  {#if status == STATUS.ERROR_INVALID}
-    <span class="error">Bad Request (Your inputs are wrong/impossible)</span>
-  {/if}
-  {#if status == STATUS.ERROR_UNAUTHORIZED}
-    <span class="error">Error. You are not allowed to do that!</span>
-  {/if}
-  {#if status == STATUS.DUPLICATE}
-    <span class="error">Error: Duplicate</span>
-  {/if}
-  {#if status == STATUS.NOT_FOUND}
-    <span class="error">Error: Not found!</span>
-  {/if}
-  {#if status == STATUS.PRIVATEUUID_MISSING}(Private UUID required){/if}
+  Status: <BaseStatus {status} />
 </div>
-
-<style>
-  .error {
-    color: red;
-  }
-  .lds-dual-ring {
-    display: inline-block;
-    vertical-align: middle;
-    width: 1em;
-    height: 1em;
-  }
-  .lds-dual-ring:after {
-    content: ' ';
-    display: block;
-    width: 0.8em;
-    height: 0.8em;
-    margin: 0.1em;
-    border-radius: 50%;
-    border: 0.075em solid #fff;
-    border-color: #fff transparent #fff transparent;
-    animation: lds-dual-ring 1.2s linear infinite;
-  }
-  @keyframes lds-dual-ring {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -57,6 +57,12 @@
       requiresVIP: true,
     },
     {
+      route: `${baseUrl}/batchwarn`,
+      title: 'Batch warn',
+      uuidRequired: true,
+      requiresVIP: true,
+    },
+    {
       route: `${baseUrl}/cachepurge`,
       title: 'Clear cache / Purge segments',
       uuidRequired: true,

--- a/src/routes/batchwarn/+page.svelte
+++ b/src/routes/batchwarn/+page.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { Config } from '../../stores/config';
+  import MultiStatus, { STATUS } from '../../components/MultiStatus.svelte';
+  import { warningTypeList, warningTypeTitles } from '../../config';
+
+  type User = {
+    userID: string,
+    type: number,
+  }
+  const section_regex = new RegExp(/\n\s*\n/,'dg'); // basically a blankline detector, TS has no idea about the 'd' flag
+  const vipnote_regex = /^\s*\**\[[\s\S]+\]\**\s*$/; // "[vip note: ...]  ", "  ***[vip note: ...]***"
+  const sbb_regex = /sb\.ltn\.fi\/userid\/([0-9a-f]{64})/i;
+  const dab_regex = /dearrow\.minibomba\.pro\/user_id\/([0-9a-f]{64})/i;
+  const uid_regex = /[0-9a-f]{64}/i;
+
+  let inputValid = false;
+  let inputText = '';
+  let defaultType = 0;
+  let status: [string, symbol][] = [];
+  let userText = '';
+  let users: Array<User> = [];
+
+  $: {
+    // Find all section bounduaries
+    const sectionBounds = Array.from(inputText.matchAll(section_regex)) as (RegExpExecArray & {indices: [[number, number]]})[]; // TS has no idea about the 'd' regex flag
+    let header: string;
+
+    switch (sectionBounds.length) {
+      case 0:
+        // no sections, all header
+        header = inputText.trim();
+        userText = '';
+        break;
+      case 1:
+        // header + main, no trailer
+        header = inputText.slice(0, sectionBounds[0].indices[0][0]); // first section
+        userText = inputText.slice(sectionBounds[0].indices[0][1]).trim();  // second section
+        break;
+      default: {
+        // header + main + maybe trailer
+        header = inputText.slice(0, sectionBounds[0].indices[0][0]); // first section
+        let trailer = inputText.slice(sectionBounds[sectionBounds.length-1].indices[0][1]);  // last section
+        if (vipnote_regex.test(trailer)) {
+          userText = inputText.slice(sectionBounds[0].indices[0][1], sectionBounds[sectionBounds.length-1].indices[0][0]); // second - second-last section
+        } else {
+          userText = inputText.slice(sectionBounds[0].indices[0][1]).trim(); // second section - end
+        }
+      }
+    }
+
+    // Find userid links in the header, one per line
+    const tmpUsers = [];
+    for (const line of header.split('\n')) {
+      let match = sbb_regex.exec(line);
+      if (match) {
+        tmpUsers.push({
+          userID: match[1].toLowerCase(),
+          type: 0 // SB
+        });
+        continue;
+      }
+
+      match = dab_regex.exec(line);
+      if (match) {
+        tmpUsers.push({
+          userID: match[1].toLowerCase(),
+          type: 1 // DA
+        });
+        continue;
+      }
+
+      match = uid_regex.exec(line);
+      if (match) {
+        tmpUsers.push({
+          userID: match[0].toLowerCase(),
+          type: defaultType,
+        });
+        continue;
+      }
+    }
+    users = tmpUsers;
+    inputValid = inputText.length > 0 && users.length > 0;
+  }
+
+
+  async function doAction() {
+    status = users.map(u => [`${warningTypeTitles[u.type]}/${u.userID}`, STATUS.WORKING]);
+    const promises = [];
+
+    for (const i in users) {
+      const user = users[i];
+      promises.push((async () => {
+        const postData: TWarnUser = {
+          issuerUserID: $Config.privateUUID,
+          userID: user.userID,
+          reason: userText,
+          type: user.type,
+          enabled: true,
+        };
+
+        const result = await fetch(`${$Config.sponsorBlockApi}/api/warnUser`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(postData),
+        }).then(function (response) {
+          return response.status;
+        });
+        if (result === 200) {
+          status[i][1] = STATUS.SUCCESS;
+        }
+        if (result === 400) {
+          status[i][1] = STATUS.ERROR_INVALID;
+        }
+        if (result === 403) {
+          status[i][1] = STATUS.ERROR_UNAUTHORIZED;
+        }
+        if (result === 409) {
+          status[i][1] = STATUS.DUPLICATE;
+        }
+
+        if (status[i][1] === STATUS.WORKING) {
+          // Still "working", but request has already finished - this means we've missed an error
+          status[i][1] = STATUS.ERROR_OTHER;
+        }
+      })());
+    }
+
+    await Promise.allSettled(promises);
+  }
+</script>
+
+<svelte:head>
+	<title>Batch warn | SponsorBlockControl</title>
+</svelte:head>
+
+<main>
+  <div class="container">
+    <fieldset>
+      <legend>Batch warn:</legend>
+      <div class="form" class:working={Object.values(status).some(s => s[1] == STATUS.WORKING)}>
+        <div>
+          <label for="warning-type">Default warn target:</label><br />
+          <select id="warning-type" bind:value={defaultType}>
+            <option value="">--- Where it applies ---</option>
+            {#each warningTypeList as warningType, index}
+              <option value={warningType}>{warningTypeTitles[index]}</option>
+            {/each}
+          </select>
+        </div>
+        <div>
+          <label for="reason">Warn log text:</label><br />
+          <textarea
+            id="reason"
+            cols="80"
+            rows="10"
+            bind:value={inputText}
+            placeholder={"https://sb.ltn.fi/userid/1234...\nhttps://dearrow.minibomba.pro/user_id/5678...\n9abc...\n\nReason...\n\n[vip note: ... (will be removed)]"}></textarea>
+        </div>
+
+        <div class="actions">
+          <button
+            type="button"
+            disabled={!inputValid}
+            on:click={doAction}
+          >Warn</button>
+        </div>
+      </div>
+    </fieldset>
+    <fieldset>
+      <legend>Preview</legend>
+      <div>
+        Targetted users:
+        <ul>
+        {#each users as user}
+          <li>{user.userID} ({warningTypeTitles[user.type]})</li>
+        {/each}
+        </ul>
+      </div>
+      <div>
+        <label for="reason-preview">Warn text to be sent to the users:</label><br />
+        <textarea 
+          id="reason-preview"
+          disabled 
+          cols="80"
+          rows="10"
+          bind:value={userText} 
+        />
+      </div>
+    </fieldset>
+
+    <MultiStatus {status} />
+  </div>
+</main>
+
+<style>
+  .form {
+    position: relative;
+  }
+  .working:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    background: rgba(0, 0, 0, 0.3);
+  }
+
+  select {
+    color: #dee2e6;
+    border: 1px solid #6c757d;
+    border-radius: .25rem;
+    background-color: #000;
+    padding: .175rem .5rem;
+  }
+
+  ul {
+    margin: 0;
+  }
+</style>

--- a/src/routes/browse/+page.svelte
+++ b/src/routes/browse/+page.svelte
@@ -99,6 +99,11 @@
         status = STATUS.NOT_FOUND;
       }
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 
   async function onSubmit() {

--- a/src/routes/cachepurge/+page.svelte
+++ b/src/routes/cachepurge/+page.svelte
@@ -29,6 +29,11 @@
     if (result === 403) {
       status = STATUS.ERROR_UNAUTHORIZED;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 
   async function doPurgeSegments() {
@@ -58,6 +63,11 @@
     }
     if (result === 403) {
       status = STATUS.ERROR_UNAUTHORIZED;
+    }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
     }
   }
 </script>

--- a/src/routes/categorychange/+page.svelte
+++ b/src/routes/categorychange/+page.svelte
@@ -38,6 +38,11 @@
     if (result === 405) {
       status = STATUS.DUPLICATE;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 </script>
 

--- a/src/routes/lockcategories/+page.svelte
+++ b/src/routes/lockcategories/+page.svelte
@@ -70,6 +70,11 @@
     if (result === 403) {
       status = STATUS.ERROR_UNAUTHORIZED;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 
   function toggleCheckboxes() {

--- a/src/routes/shadowban/+page.svelte
+++ b/src/routes/shadowban/+page.svelte
@@ -43,6 +43,11 @@
     if (result === 403) {
       status = STATUS.ERROR_UNAUTHORIZED;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 </script>
 

--- a/src/routes/username/+page.svelte
+++ b/src/routes/username/+page.svelte
@@ -26,6 +26,11 @@
     if (response.status === 403) {
       status = STATUS.ERROR_UNAUTHORIZED;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
     return '';
   }
 
@@ -52,6 +57,11 @@
     }
     if (response.status === 403) {
       status = STATUS.ERROR_UNAUTHORIZED;
+    }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
     }
   }
 

--- a/src/routes/vip/+page.svelte
+++ b/src/routes/vip/+page.svelte
@@ -42,6 +42,11 @@
     if (result === 403) {
       status = STATUS.ERROR_UNAUTHORIZED;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 </script>
 

--- a/src/routes/voteonsegment/+page.svelte
+++ b/src/routes/voteonsegment/+page.svelte
@@ -35,6 +35,11 @@
     if (result === 405) {
       status = STATUS.DUPLICATE;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 </script>
 

--- a/src/routes/warnuser/+page.svelte
+++ b/src/routes/warnuser/+page.svelte
@@ -50,6 +50,11 @@
     if (result === 409) {
       status = STATUS.DUPLICATE;
     }
+
+    if (status === STATUS.WORKING) {
+      // Still "working", but request has already finished - this means we've missed an error
+      status = STATUS.ERROR_OTHER;
+    }
   }
 </script>
 


### PR DESCRIPTION
This new page accepts a message in the format that would be sent to the #tip-log channel, extracts out the target users and services, removes the log-only user headers & vip note trailers and sends the tip to all target users at once.

This feature might be convenient for some users (incl. me) even for single-user tips.

The "warn log" format is as follows:
- text, has sections separated by a blank (or whitespace-only) line
- first section is a "header" containing one userid link per line (other, additional text is permitted)
  - this section is omitted from the actual warn message
  - links to sb.ltn.fi are recognized as SponsorBlock users
  - links to dearrow.minibomba.pro are recognized as DeArrow users
  - other 64-char hex strings use the service selected from a select menu
- the warn body, can span multiple sections
- last section may be a "trailer" with only vip notes
  - to be recognized as a vip note trailer, the section must start with [ and end with ], may be styled with `*` characters
  - if recognized, this section is omitted from the actual warn message

Also fixed the status spinner getting stuck on unexpected errors, probably - will switch to a generic "Error" status instead